### PR TITLE
replacing browser router with hash router

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
+    "predeploy" : "npm run build",
     "deploy": "gh-pages -d build",
     "start": "react-scripts start",
     "build": "react-scripts build --no-warnings-as-errors",

--- a/src/App.js
+++ b/src/App.js
@@ -37,7 +37,7 @@ function App() {
       {/* <Sidebar pageWrapId={'page-wrap'} outerContainerId={'outer-container'} /> */}
 
         <div id='page-wrap'>
-          <Routes> 
+          <Routes basename="/Rawdah_Institute"> 
             <Route path="/" element={<Navigate replace to="/home" />} />
             <Route path="/home" element={<Home />} />
             <Route path="/online-class" element={<OnlineClass />} />

--- a/src/index.js
+++ b/src/index.js
@@ -2,16 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter as Router } from 'react-router-dom';
 //import Head from "next/head";
 
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-   <BrowserRouter basename="/Rawdah_Institute">
+   <Router>
       <App />
-   </BrowserRouter>
+   </Router>
     
   </React.StrictMode>
 );


### PR DESCRIPTION
With Browser Router gh-pages will not allow you to access routes directly, as the server does not know how to handle these routes. Hash Router does not require special server configs.Hash router is used when deploying a single-page app to a location that doesn't support HTML5 History API (e.g., GitHub Pages).